### PR TITLE
whisper: bloom filter is not changed after unsubscribe

### DIFF
--- a/whisper/whisperv6/whisper_test.go
+++ b/whisper/whisperv6/whisper_test.go
@@ -892,3 +892,28 @@ func TestBloom(t *testing.T) {
 		t.Fatalf("retireved wrong bloom filter")
 	}
 }
+
+func TestBloomFilterIsChanged(t *testing.T) {
+	w := New(&DefaultConfig)
+	w.SetBloomFilter(make([]byte, 64))
+	filter1, err := generateFilter(t, true)
+	if err != nil {
+		t.Fatalf("failed generateMessageParams with seed %d: %s.", seed, err)
+	}
+	bloom := w.BloomFilter()
+	id, err := w.Subscribe(filter1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bloomSubscribed := w.BloomFilter()
+	if bloomFilterMatch(bloom, bloomSubscribed) {
+		t.Fatalf("expected %v != %v", bloom, bloomSubscribed)
+	}
+	if err := w.Unsubscribe(id); err != nil {
+		t.Fatal(err)
+	}
+	bloomUnsub := w.BloomFilter()
+	if bloomFilterMatch(bloomUnsub, bloomSubscribed) {
+		t.Fatalf("expected %v != %v", bloomUnsub, bloomSubscribed)
+	}
+}


### PR DESCRIPTION
Illustration of [clarity-bot's](https://clarity-bot.com) structure-diffs using a cloned [Pull Request](https://github.com/ethereum/go-ethereum/pull/16116)  from the official  ethereum/go-ethereum repository.